### PR TITLE
Web Parser on GO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # webparser
+
+Простой веб-парсер на Go 1.24.3. Скачивает HTML по заданному URL и выводит все ссылки.
+
+## Пример
+
+```bash
+go run main.go https://example.com
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module webparser
+
+go 1.24.3
+
+require golang.org/x/net v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
+golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"golang.org/x/net/html"
+)
+
+// main downloads an HTML document from the provided URL and
+// prints all hyperlinks found in the page.
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s URL\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	resp, err := http.Get(os.Args[1])
+	if err != nil {
+		log.Fatalf("failed to fetch URL: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Fatalf("unexpected status code: %s", resp.Status)
+	}
+
+	doc, err := html.Parse(resp.Body)
+	if err != nil {
+		log.Fatalf("failed to parse HTML: %v", err)
+	}
+
+	// Recursively traverse the HTML node tree and print href attributes.
+	var f func(*html.Node)
+	f = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			for _, attr := range n.Attr {
+				if attr.Key == "href" {
+					fmt.Println(attr.Val)
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			f(c)
+		}
+	}
+	f(doc)
+}


### PR DESCRIPTION
## Summary
- implement basic Go 1.24.3 program that downloads a URL and prints all `href` links
- document usage example in README

## Testing
- `go run main.go https://example.com`
- `go build ./...`
